### PR TITLE
feat: add support for auto-merge setting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,16 +55,19 @@ jobs:
         uses: tmknom/checkout-action@v1
 
       - name: Exercise
+        id: exercise
         uses: ./
         with:
           pull-request: ${{ steps.setup.outputs.pr-branch }}
 
       - name: Verify
         env:
+          AUTO_MERGE: ${{ steps.exercise.outputs.auto-merge }}
           PR_BRANCH: ${{ steps.setup.outputs.pr-branch }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
+          test "${AUTO_MERGE}" = "true"
           result="$(gh pr view "${PR_BRANCH}" --json state --jq .state)"
           test "${result}" = "MERGED"
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ This action merges a specified pull request.
 
 ## Outputs
 
-N/A
+| Name | Description |
+| :--- | :---------- |
+| auto-merge | Indicates whether the auto-merge setting is enabled for the repository. |
 
 <!-- actdocs end -->
 

--- a/action.yml
+++ b/action.yml
@@ -17,15 +17,39 @@ inputs:
     required: true
     description: Specifies the pull request to merge as a `number`, `url`, or `branch`.
 
+outputs:
+  auto-merge:
+    value: ${{ steps.repository.outputs.auto-merge }}
+    description: Indicates whether the auto-merge setting is enabled for the repository.
+
 runs:
   using: composite
 
   steps:
-    - name: Merge
+    - name: Describe repository settings
+      id: repository
       env:
-        PULL_REQUEST: ${{ inputs.pull-request }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -x
-        gh pr merge "${PULL_REQUEST}" --merge
+        auto_merge="$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/repos/${GITHUB_REPOSITORY}" \
+          --jq '.allow_auto_merge')"
+        echo "auto-merge=${auto_merge}" >> "${GITHUB_OUTPUT}"
+      shell: bash
+
+    - name: Merge
+      env:
+        PULL_REQUEST: ${{ inputs.pull-request }}
+        AUTO_MERGE: ${{ steps.repository.outputs.auto-merge }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -x
+        declare -a flags=(--merge)
+        if [[ "${AUTO_MERGE}" == "true" ]]; then
+          flags+=(--auto)
+        fi
+        gh pr merge "${PULL_REQUEST}" "${flags[@]}"
       shell: bash


### PR DESCRIPTION
## About auto-merge

You can increase development velocity by enabling auto-merge for a pull request so that the pull request will merge automatically when all merge requirements are met.

If you enable auto-merge for a pull request, the pull request will merge automatically when all required reviews are met and all required status checks have passed.
Auto-merge prevents you from waiting around for requirements to be met, so you can move on to other tasks.

Before you can use auto-merge with a pull request, auto-merge must be enabled for the repository.
If you allow auto-merge for pull requests in your repository, people with write permissions can configure individual pull requests in the repository to merge automatically when all merge requirements are met.
If someone who does not have write permissions pushes changes to a pull request that has auto-merge enabled, auto-merge will be disabled for that pull request.

## References

- [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
- [Managing auto-merge for pull requests in your repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository)
